### PR TITLE
Add a 'Force login' feature

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -39,7 +39,7 @@ if (OCP\App::isEnabled('user_cas')) {
 	OCP\Util::connectHook('OC_User', 'post_login', 'OC_USER_CAS_Hooks', 'post_login');
 	OCP\Util::connectHook('OC_User', 'logout', 'OC_USER_CAS_Hooks', 'logout');
 
-	$force_login = OCP\Config::getAppValue('user_cas', 'cas_force_login', false) && shouldEnforceAuthentication();
+	$force_login = shouldEnforceAuthentication();
 
 	if( (isset($_GET['app']) && $_GET['app'] == 'user_cas') || $force_login ) {
 
@@ -77,6 +77,10 @@ if (OCP\App::isEnabled('user_cas')) {
 function shouldEnforceAuthentication()
 {
 	if (OC::$CLI) {
+		return false;
+	}
+
+	if (OCP\Config::getAppValue('user_cas', 'cas_force_login', false) === false) {
 		return false;
 	}
 

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -39,7 +39,9 @@ if (OCP\App::isEnabled('user_cas')) {
 	OCP\Util::connectHook('OC_User', 'post_login', 'OC_USER_CAS_Hooks', 'post_login');
 	OCP\Util::connectHook('OC_User', 'logout', 'OC_USER_CAS_Hooks', 'logout');
 
-	if( isset($_GET['app']) && $_GET['app'] == 'user_cas' ) {
+	$force_login = OCP\Config::getAppValue('user_cas', 'cas_force_login', false) && shouldEnforceAuthentication();
+
+	if( (isset($_GET['app']) && $_GET['app'] == 'user_cas') || $force_login ) {
 
 		if (OC_USER_CAS :: initialized_php_cas()) {
 
@@ -68,3 +70,29 @@ if (OCP\App::isEnabled('user_cas')) {
 	}
 
 }
+
+/**
+ * Check if login should be enforced using user_cas
+ */
+function shouldEnforceAuthentication()
+{
+	if (OC::$CLI) {
+		return false;
+	}
+
+	if (OCP\User::isLoggedIn() || isset($_GET['admin_login'])) {
+		return false;
+	}
+
+	$script = basename($_SERVER['SCRIPT_FILENAME']);
+	return !in_array(
+		$script,
+		array(
+			'cron.php',
+			'public.php',
+			'remote.php',
+			'status.php',
+		)
+	);
+}
+

--- a/settings.php
+++ b/settings.php
@@ -24,9 +24,9 @@
 
 OC_Util::checkAdminUser();
 
-$params = array('cas_server_version', 'cas_server_hostname', 'cas_server_port', 'cas_server_path', 'cas_autocreate', 'cas_update_user_data',
-	'cas_protected_groups', 'cas_default_group', 'cas_email_mapping', 'cas_displayName_mapping','cas_group_mapping','cas_cert_path',
-	'cas_debug_file', 'cas_php_cas_path', 'cas_link_to_ldap_backend', 'cas_disable_logout');
+$params = array('cas_server_version', 'cas_server_hostname', 'cas_server_port', 'cas_server_path', 'cas_force_login', 'cas_autocreate',
+	'cas_update_user_data', 'cas_protected_groups', 'cas_default_group', 'cas_email_mapping', 'cas_displayName_mapping','cas_group_mapping',
+	'cas_cert_path', 'cas_debug_file', 'cas_php_cas_path', 'cas_link_to_ldap_backend', 'cas_disable_logout');
 
 OCP\Util::addscript('user_cas', 'settings');
 OCP\Util::addStyle('user_cas', 'settings');
@@ -39,7 +39,7 @@ if ($_POST) {
 		if (isset($_POST[$param])) {
 			OCP\Config::setAppValue('user_cas', $param, $_POST[$param]);
 		}
-	        elseif (in_array($param,array('cas_autocreate','cas_update_user_data','cas_link_to_ldap_backend','cas_disable_logout'))) {
+		elseif (in_array($param,array('cas_force_login', 'cas_autocreate','cas_update_user_data','cas_link_to_ldap_backend','cas_disable_logout'))) {
 			// unchecked checkboxes are not included in the post paramters
 			OCP\Config::setAppValue('user_cas', $param, 0);
 		}

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -29,6 +29,7 @@
 
 	</fieldset>
 	<fieldset id="casSettings-2">
+	<p><input type="checkbox" id="cas_force_login" name="cas_force_login" <?php print_unescaped((($_['cas_force_login'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_force_login"><?php p($l->t('Force user login using CAS?'));?></label></p>
 	<p><input type="checkbox" id="cas_autocreate" name="cas_autocreate" <?php print_unescaped((($_['cas_autocreate'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_autocreate"><?php p($l->t('Autocreate user after CAS login?'));?></label></p>
 	<p><input type="checkbox" id="cas_link_to_ldap_backend" name="cas_link_to_ldap_backend" <?php print_unescaped((($_['cas_link_to_ldap_backend'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_link_to_ldap_backend"><?php p($l->t('Link CAS authentication with LDAP users and groups backend'));?></label></p>
 	<p><input type="checkbox" id="cas_update_user_data" name="cas_update_user_data" <?php print_unescaped((($_['cas_update_user_data'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_update_user_data"><?php p($l->t('Update user data after login?'));?></label></p>


### PR DESCRIPTION
Adds a new setting called `cas_force_login`, which is disabled by default.

When enabled, non-authenticated web requests are forced to log in using CAS.
Certain URLs are excluded:

* cron.php
* public.php
* remote.php
* status.php

Accessing to the ownCloud login form can be achieved by appending `?admin_login` to the URL.