### PR TITLE
Added some missing checks

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -61,7 +61,7 @@ if (OCP\App::isEnabled('user_cas')) {
 	}
 
 
-	if (!OCP\User::isLoggedIn()) {
+	if (!phpCAS::isAuthenticated() && !OCP\User::isLoggedIn()) {
 
 		// Load js code in order to render the CAS link and to hide parts of the normal login form
 		OCP\Util::addScript('user_cas', 'login');

--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -63,7 +63,7 @@ class OC_USER_CAS_Hooks {
 					OC_Log::write('cas','Using default group "'.$casBackend->defaultGroup.'" for the user: '.$uid, OC_Log::DEBUG);
 				}
 
-				if (!$userDatabase->userExists($uid)) {
+				if (!$userDatabase->userExists($uid) && $casBackend->autocreate) {
 					// create users if they do not exist
 					if (preg_match( '/[^a-zA-Z0-9 _\.@\-]/', $uid)) {
 						OC_Log::write('cas','Invalid username "'.$uid.'", allowed chars "a-zA-Z0-9" and "_.@-" ',OC_Log::DEBUG);


### PR DESCRIPTION
In the hooks.php you were creating the new user if it didn't existed without including the actual value of the autocreate propery in the conditional.

In the app.php you were only checking OCP\User::isLoggedIn() which caused the Authenticate with CAS  button to be displayed even when the user authenticated with CAS.