### PR TITLE
Adding "Service URL" for Owncloud behind reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ CAS Server
 
 **CAS Server Path**: The directory of your CAS. In common setups this path is /cas 
 
+**Service URL**: Service URL used to CAS authentication and redirection. Usefull when behind a reverse proxy.
+
 **Certification file**: If you don't want to validate the certificate (i.e. self-signed certificates) then leave this blank. Otherwise enter the path to the certificate.
 
 **Disable CAS logout**: If checked, you will only be logged out from owncloud

--- a/l10n/fr.php
+++ b/l10n/fr.php
@@ -10,6 +10,7 @@ $TRANSLATIONS = array(
 "CAS Server Hostname" => "Nom d'hôte du serveur CAS",
 "CAS Server Port" => "Port du serveur CAS",
 "CAS Server Path" => "Chemin du serveur CAS",
+"Service URL" => "URL du service",
 "Certification file path (.crt). Leave empty if dont want to validate" => "Chemin du fichier de certification (.crt). Laisser vide si vous ne souhaitez pas de validation",
 "Disable CAS logout (do only OwnCloud logout)" => "Désactiver la déconnexion CAS (déconnexion d'Owncloud uniquement)",
 "Autocreate user after CAS login?" => "Créer l'utilisateur automatiquement après la connexion CAS ?",

--- a/settings.php
+++ b/settings.php
@@ -26,7 +26,7 @@ OC_Util::checkAdminUser();
 
 $params = array('cas_server_version', 'cas_server_hostname', 'cas_server_port', 'cas_server_path', 'cas_force_login', 'cas_autocreate',
 	'cas_update_user_data', 'cas_protected_groups', 'cas_default_group', 'cas_email_mapping', 'cas_displayName_mapping','cas_group_mapping',
-	'cas_cert_path', 'cas_debug_file', 'cas_php_cas_path', 'cas_link_to_ldap_backend', 'cas_disable_logout');
+	'cas_cert_path', 'cas_debug_file', 'cas_php_cas_path', 'cas_link_to_ldap_backend', 'cas_disable_logout', 'cas_service_url');
 
 OCP\Util::addscript('user_cas', 'settings');
 OCP\Util::addStyle('user_cas', 'settings');

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -25,8 +25,8 @@
 		<p><label for="cas_server_port"><?php p($l->t('CAS Server Port'));?></label><input type="text" id="cas_server_port" name="cas_server_port" value="<?php p($_['cas_server_port']); ?>"></p>
 		<p><label for="cas_server_path"><?php p($l->t('CAS Server Path'));?></label><input type="text" id="cas_server_path" name="cas_server_path" value="<?php p($_['cas_server_path']); ?>"></p>
 		<p><label for="cas_service_url"><?php p($l->t('Service URL'));?></label><input type="text" id="cas_service_url" name="cas_service_url" value="<?php p($_['cas_service_url']); ?>"></p>
-        <p><label for="cas_cert_path"><?php p($l->t('Certification file path (.crt). Leave empty if dont want to validate'));?></label><input type="text" id="cas_cert_path" name="cas_cert_path" value="<?php p($_['cas_cert_path']); ?>"></p>
-        <p><input type="checkbox" id="cas_disable_logout" name="cas_disable_logout" <?php print_unescaped((($_['cas_disable_logout'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_disable_logout"><?php p($l->t('Disable CAS logout (do only OwnCloud logout)'));?></label></p>
+		<p><label for="cas_cert_path"><?php p($l->t('Certification file path (.crt). Leave empty if dont want to validate'));?></label><input type="text" id="cas_cert_path" name="cas_cert_path" value="<?php p($_['cas_cert_path']); ?>"></p>
+		<p><input type="checkbox" id="cas_disable_logout" name="cas_disable_logout" <?php print_unescaped((($_['cas_disable_logout'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_disable_logout"><?php p($l->t('Disable CAS logout (do only OwnCloud logout)'));?></label></p>
 	</fieldset>
 	<fieldset id="casSettings-2">
 	<p><input type="checkbox" id="cas_force_login" name="cas_force_login" <?php print_unescaped((($_['cas_force_login'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_force_login"><?php p($l->t('Force user login using CAS?'));?></label></p>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -24,10 +24,9 @@
 		<p><label for="cas_server_hostname"><?php p($l->t('CAS Server Hostname'));?></label><input type="text" id="cas_server_hostname" name="cas_server_hostname" value="<?php p($_['cas_server_hostname']); ?>"></p>
 		<p><label for="cas_server_port"><?php p($l->t('CAS Server Port'));?></label><input type="text" id="cas_server_port" name="cas_server_port" value="<?php p($_['cas_server_port']); ?>"></p>
 		<p><label for="cas_server_path"><?php p($l->t('CAS Server Path'));?></label><input type="text" id="cas_server_path" name="cas_server_path" value="<?php p($_['cas_server_path']); ?>"></p>
-                <p><label for="cas_cert_path"><?php p($l->t('Certification file path (.crt). Leave empty if dont want to validate'));?></label><input type="text" id="cas_cert_path" name="cas_cert_path" value="<?php p($_['cas_cert_path']); ?>"></p>
-                <p><input type="checkbox" id="cas_disable_logout" name="cas_disable_logout" <?php print_unescaped((($_['cas_disable_logout'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_disable_logout"><?php p($l->t('Disable CAS logout (do only OwnCloud logout)'));?></label></p>
-
-
+		<p><label for="cas_service_url"><?php p($l->t('Service URL'));?></label><input type="text" id="cas_service_url" name="cas_service_url" value="<?php p($_['cas_service_url']); ?>"></p>
+        <p><label for="cas_cert_path"><?php p($l->t('Certification file path (.crt). Leave empty if dont want to validate'));?></label><input type="text" id="cas_cert_path" name="cas_cert_path" value="<?php p($_['cas_cert_path']); ?>"></p>
+        <p><input type="checkbox" id="cas_disable_logout" name="cas_disable_logout" <?php print_unescaped((($_['cas_disable_logout'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_disable_logout"><?php p($l->t('Disable CAS logout (do only OwnCloud logout)'));?></label></p>
 	</fieldset>
 	<fieldset id="casSettings-2">
 	<p><input type="checkbox" id="cas_force_login" name="cas_force_login" <?php print_unescaped((($_['cas_force_login'] != false) ? 'checked="checked"' : '')); ?>> <label class='checkbox' for="cas_force_login"><?php p($l->t('Force user login using CAS?'));?></label></p>

--- a/user_cas.php
+++ b/user_cas.php
@@ -70,6 +70,7 @@ class OC_USER_CAS extends OC_User_Backend {
 			$casDebugFile=OCP\Config::getAppValue('user_cas', 'cas_debug_file', '');
 			$casCertPath = OCP\Config::getAppValue('user_cas', 'cas_cert_path', '');
 			$php_cas_path=OCP\Config::getAppValue('user_cas', 'cas_php_cas_path', 'CAS.php');
+			$cas_service_url = OCP\Config::getAppValue('user_cas', 'cas_service_url', '');
 
 			if (!class_exists('phpCAS')) {
 				if (empty($php_cas_path)) $php_cas_path='CAS.php';
@@ -84,7 +85,13 @@ class OC_USER_CAS extends OC_User_Backend {
 			if ($casDebugFile !== '') {
 				phpCAS::setDebug($casDebugFile);
 			}
+			
 			phpCAS::client($casVersion,$casHostname,(int)$casPort,$casPath,false);
+			
+            if (!empty($cas_service_url)) {
+				phpCAS::setFixedServiceURL($cas_service_url);
+            }
+						
 			if(!empty($casCertPath)) {
 				phpCAS::setCasServerCACert($casCertPath);
 			}

--- a/user_cas.php
+++ b/user_cas.php
@@ -88,9 +88,9 @@ class OC_USER_CAS extends OC_User_Backend {
 			
 			phpCAS::client($casVersion,$casHostname,(int)$casPort,$casPath,false);
 			
-            if (!empty($cas_service_url)) {
+			if (!empty($cas_service_url)) {
 				phpCAS::setFixedServiceURL($cas_service_url);
-            }
+			}
 						
 			if(!empty($casCertPath)) {
 				phpCAS::setCasServerCACert($casCertPath);


### PR DESCRIPTION
I have added a "Service URL" setting to be able to use Owncloud with user_cas behind a reverse proxy. It is use to specify the real service URL when it is behind a reverse proxy, like declared in the issue #3 .