### PR TITLE
Fix blank page with LDAP backend enabled (PHP7 / OwnCloud 9.0.2 RC1) #32

### DIFF
--- a/lib/ldap_backend_adapter.php
+++ b/lib/ldap_backend_adapter.php
@@ -59,7 +59,8 @@ class LdapBackendAdapter extends \OCA\user_ldap\USER_LDAP {
 				new \OCA\user_ldap\lib\LogWrapper(),
 				\OC::$server->getAvatarManager(),
 				new \OCP\Image(),
-				$dbc
+				$dbc,
+				\OC::$server->getUserManager()
 			);
 			$this->connection = new \OCA\user_ldap\lib\Connection($this->ldap,$configPrefixes[0]);
 


### PR DESCRIPTION
7th argument to **new \OCA\user_ldap\lib\user\Manager()** was missing.