### PR TITLE
Fixed compatibility issue with OC 9.1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+Version 1.2
+-------------
+* fix compatibility issue with ownCloud 9.1
+
 Version 0.1.1
 -------------
 * Added CSRF protection on setting form

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Authors
 * David Willinger (Leonis Holding)  - https://github.com/leoniswebDAVe
 * Florian Hintermeier (Leonis Holding)  - https://github.com/leonisCacheFlo
 * brenard - https://github.com/brenard
+* Takayuki Nagai - https://github.com/nagai-takayuki
 
 Links
 -------

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -6,6 +6,7 @@
  * @author Sixto Martin <sixto.martin.garcia@gmail.com>
  * @copyright Sixto Martin Garcia. 2012
  * @copyright Leonis. 2014 <devteam@leonis.at>
+ * @copyright Takayuki NAGAI 2016
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -44,14 +45,13 @@ if (OCP\App::isEnabled('user_cas')) {
 	if( (isset($_GET['app']) && $_GET['app'] == 'user_cas') || $force_login ) {
 
 		if (OC_USER_CAS :: initialized_php_cas()) {
-
 			phpCAS::forceAuthentication();
 
-			if (!OC_User::login('', '')) {
-				$error = true;
-				\OCP\Util::writeLog('cas','Error trying to authenticate the user', \OCP\Util::DEBUG);
-			}
-		
+			$user = phpCAS::getUser();
+			$application = new \OC\Core\Application();
+			$loginController = $application->getContainer()->query('LoginController');
+			$loginController->tryLogin($user,NULL,NULL);
+
 			if (isset($_SERVER["QUERY_STRING"]) && !empty($_SERVER["QUERY_STRING"]) && $_SERVER["QUERY_STRING"] != 'app=user_cas') {
 				header( 'Location: ' . OC::$WEBROOT . '/?' . $_SERVER["QUERY_STRING"]);
 				exit();
@@ -61,7 +61,6 @@ if (OCP\App::isEnabled('user_cas')) {
 		OC::$REQUESTEDAPP = '';
 		OC_Util::redirectToDefaultPage();
 	}
-
 
 	if (!phpCAS::isAuthenticated() && !OCP\User::isLoggedIn()) {
 		OC_App::registerLogIn(array('href' => '?app=user_cas', 'name' => 'CAS Login'));

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,9 +4,9 @@
 	<name>CAS user and group backend</name>
 	<description>Authenticate Users by a CAS SERVER</description>
 	<licence>AGPL</licence>
-	<author>Leonis Holding</author>
-	<require>7.0.1</require>
-	<version>1.1</version>
+	<author>Takayuki NAGAI</author>
+	<require>9.1.0</require>
+	<version>1.2</version>
 	<types>
         <prelogin/>
         <authentication/>

--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -5,6 +5,7 @@
  * @author Sixto Martin <sixto.martin.garcia@gmail.com>
  * @copyright Sixto Martin Garcia. 2012
  * @copyright Leonis. 2014 <devteam@leonis.at>
+ * @copyright Takayuki NAGAI 2016
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -30,7 +31,7 @@ class OC_USER_CAS_Hooks {
 
 		$uid = $parameters['uid'];
 		$casBackend = OC_USER_CAS::getInstance();
-		$userDatabase = new OC_User_Database;
+		$userDatabase = new OC\User\Database;
 
 		if (phpCAS::isAuthenticated()) {
 			// $cas_attributes may vary in name, therefore attributes are fetched to $attributes
@@ -70,7 +71,7 @@ class OC_USER_CAS_Hooks {
 						return false;
 					}
 					else {
-						$random_password = OC_Util::generateRandomBytes(20);
+						$random_password = \OCP\Util::generateRandomBytes(20);
 						\OCP\Util::writeLog('cas','Creating new user: '.$uid, \OCP\Util::DEBUG);
 						$userDatabase->createUser($uid, $random_password);
 

--- a/lib/ldap_backend_adapter.php
+++ b/lib/ldap_backend_adapter.php
@@ -5,6 +5,7 @@
  *
  * @author Sixto Martin <sixto.martin.garcia@gmail.com>
  * @copyright Sixto Martin Garcia. 2012
+ * @copyright Takayuki NAGAI 2016
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -29,10 +30,9 @@
  * This class come from another owncloud plugins : https://github.com/AndreasErgenzinger/user_shibboleth
  */
 
-
 namespace OCA\user_cas\lib;
 
-class LdapBackendAdapter extends \OCA\user_ldap\USER_LDAP {
+class LdapBackendAdapter extends \OCA\User_LDAP\User_LDAP {
 
 	private $enabled;
 	private $connected = false;
@@ -49,21 +49,22 @@ class LdapBackendAdapter extends \OCA\user_ldap\USER_LDAP {
 
 	private function connect() {
 		if (!$this->connected) {
-			$helper = new \OCA\user_ldap\lib\Helper();
+			$helper = new \OCA\User_LDAP\Helper();
 			$configPrefixes = $helper->getServerConfigurationPrefixes(true);
-			$this->ldap = new \OCA\user_ldap\lib\LDAP();
+			$this->ldap = new \OCA\User_LDAP\LDAP();
 			$dbc = \OC::$server->getDatabaseConnection();
-			$this->usermanager = new \OCA\user_ldap\lib\user\Manager(
+			$this->usermanager = new \OCA\User_LDAP\User\Manager(
 				\OC::$server->getConfig(),
-				new \OCA\user_ldap\lib\FilesystemHelper(),
-				new \OCA\user_ldap\lib\LogWrapper(),
+				new \OCA\User_LDAP\FilesystemHelper(),
+				new \OCA\User_LDAP\LogWrapper(),
 				\OC::$server->getAvatarManager(),
 				new \OCP\Image(),
-				$dbc
+				$dbc,
+				\OC::$server->getUserManager()
 			);
-			$this->connection = new \OCA\user_ldap\lib\Connection($this->ldap,$configPrefixes[0]);
+			$this->connection = new \OCA\User_LDAP\Connection($this->ldap,$configPrefixes[0]);
 
-			$this->access = new \OCA\user_ldap\lib\Access($this->connection, $this->ldap, $this->usermanager);
+			$this->access = new \OCA\User_LDAP\Access($this->connection, $this->ldap, $this->usermanager);
 
 			$this->access->setUserMapper(new \OCA\User_LDAP\Mapping\UserMapping($dbc));
 			$this->access->setGroupMapper(new \OCA\User_LDAP\Mapping\GroupMapping($dbc));

--- a/user_cas.php
+++ b/user_cas.php
@@ -22,7 +22,7 @@
  *
  */
 
-#require_once(__DIR__ . '/lib/ldap_backend_adapter.php'); // Not required in 8.2, we now have an autoloader 
+require_once(__DIR__ . '/lib/ldap_backend_adapter.php');
 use OCA\user_cas\lib\LdapBackendAdapter;
 
 class OC_USER_CAS extends OC_User_Backend {


### PR DESCRIPTION
Issue:
Due to a lot of changes in class structure and the change in authentication framework, user_cas won't work in OC 9.1

Changes:
- Updated old class names to new class names
- Modified app.php to call tryLogin() through LoginController in place of calling OC_User::login()
